### PR TITLE
Replace deprecated method 'setting_getbool' with 'settings:get_bool'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -260,7 +260,7 @@ function farming.place_seed(itemstack, placer, pointed_thing, plantname)
 
 	-- add the node and remove 1 item from the itemstack
 	minetest.add_node(pt.above, {name=plantname, param2 = 1})
-	if not minetest.setting_getbool("creative_mode") then
+	if not minetest.settings:get_bool("creative_mode") then
 		itemstack:take_item()
 	end
 	return itemstack


### PR DESCRIPTION
May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267