### PR TITLE
Fix 'scarecrow_light' description to match locale files

### DIFF
--- a/pumpkin.lua
+++ b/pumpkin.lua
@@ -352,7 +352,7 @@ minetest.register_craft({
 })
 
 minetest.register_node(":farming:scarecrow_light", {
-	description = S("Scarecrow With light"),
+	description = S("Scarecrow With Light"),
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",


### PR DESCRIPTION
Description in *pumpkin.lua* was "Scarecrow With light". But in locale translations it is "Scarecrow With Light".