### PR TITLE
Replace deprecated function 'intllib.Getter'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,7 @@
 farming.registered_plants = {}
 
 -- Boilerplate to support localized strings if intllib mod is installed.
-if (minetest.get_modpath("intllib")) then
+if (minetest.global_exists("intllib")) then
 	dofile(minetest.get_modpath("intllib").."/intllib.lua")
 	farming.S = intllib.Getter(minetest.get_current_modname())
 else

--- a/init.lua
+++ b/init.lua
@@ -3,7 +3,11 @@ farming.registered_plants = {}
 -- Boilerplate to support localized strings if intllib mod is installed.
 if (minetest.global_exists("intllib")) then
 	dofile(minetest.get_modpath("intllib").."/intllib.lua")
-	farming.S = intllib.Getter(minetest.get_current_modname())
+	if intllib.make_gettext_pair then
+		farming.S = intllib.make_gettext_pair(minetest.get_current_modname())
+	else
+		farming.S = intllib.Getter(minetest.get_current_modname())
+	end
 else
 	farming.S = function ( s ) return s end
 end


### PR DESCRIPTION
- Check first for *intllib.make_gettext_pair*, otherwise continue using
deprecated function *intllib.Getter*.
- Call *minetest.global_exists* in place of *minetest.get_modpath* for *intllib* check (better practice in my opinion)